### PR TITLE
Always load Font Awesome CSS over HTTPS

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -6,7 +6,7 @@
 
     <title>Files within {{directory}}</title>
 
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
     <link rel="stylesheet" href="{{assetDir}}/styles.css">
   </head>
 


### PR DESCRIPTION
There is no reason not to load the Font Awesome CSS file over HTTPS in all cases.

Protocol-relative URLs are an anti-pattern. https://github.com/konklone/cdns-to-https#conclusion-cdns-should-redirect-to-https