### PR TITLE
Add `rel=noopener` with fallback

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -31,7 +31,7 @@
     </main>
 
     <aside>
-      <p>Node {{nodeVersion}} and <a href="https://github.com/zeit/list" target="_blank">list</a> running @ localhost:{{port}}</p>
+      <p>Node {{nodeVersion}} and <a href="https://github.com/zeit/list" target="_blank" rel="noopener noreferrer">list</a> running @ localhost:{{port}}</p>
     </aside>
   </body>
 </html>


### PR DESCRIPTION
This ensures that github.com can not mess with the `list`-powered HTML document in any way.

See https://mathiasbynens.github.io/rel-noopener/ for more information.