### PR TITLE
Fix route links

### DIFF
--- a/bin/list
+++ b/bin/list
@@ -152,7 +152,7 @@ const renderDirectory = async dir => {
 
     paths.push({
       name: pathParts[part],
-      url: '/' + parents.join('/')
+      url: parents.join('/')
     })
   }
 


### PR DESCRIPTION
<img width="202" alt="screen shot 2016-10-10 at 5 25 22 pm" src="https://cloud.githubusercontent.com/assets/4324982/19251822/4f49d9b6-8f0f-11e6-9834-ab22f59d471c.png">

If I click a link in the route (see image) it will take me to http://link. So for example, if I click on `repos` I would be redirected to [http://repos](http://repos).

This simple change fixed it, but I'm not sure if this affects some other code.