### PR TITLE
Send custom 404 page if it exists

### DIFF
--- a/bin/list
+++ b/bin/list
@@ -172,8 +172,17 @@ const handler = async (req, res) => {
 
   related = decodeURIComponent(path.format(related))
 
+  let notFoundResponse
+
+  try {
+    const custom404Path = path.join(current, '/404.html')
+    notFoundResponse = fs.readFileSync(custom404Path, 'utf-8')
+  } catch (err) {
+    notFoundResponse = 'Not Found'
+  }
+
   if (!fs.existsSync(related) && flags.single === undefined) {
-    return send(res, 404, 'Not found')
+    return send(res, 404, notFoundResponse)
   }
 
   // Check if file or directory path
@@ -181,7 +190,7 @@ const handler = async (req, res) => {
     let indexPath = path.join(related, '/index.html')
 
     if (!await isDir(related) && flags.single === undefined) {
-      return send(res, 404, 'Not found')
+      return send(res, 404, notFoundResponse)
     }
 
     res.setHeader('Content-Type', mime.contentType(path.extname(indexPath)))
@@ -198,7 +207,7 @@ const handler = async (req, res) => {
       // And if it doesn't, see if it's a single page application
       // If that's not true either, send an error
       if (!flags.single) {
-        return send(res, 404, 'Not found')
+        return send(res, 404, notFoundResponse)
       }
 
       // But IF IT IS true, load the SPA's root index file

--- a/bin/list
+++ b/bin/list
@@ -176,7 +176,7 @@ const handler = async (req, res) => {
 
   try {
     const custom404Path = path.join(current, '/404.html')
-    notFoundResponse = fs.readFileSync(custom404Path, 'utf-8')
+    notFoundResponse = await fs.readFile(custom404Path, 'utf-8')
   } catch (err) {}
 
   if (!fs.existsSync(related) && flags.single === undefined) {

--- a/bin/list
+++ b/bin/list
@@ -172,14 +172,12 @@ const handler = async (req, res) => {
 
   related = decodeURIComponent(path.format(related))
 
-  let notFoundResponse
+  let notFoundResponse = 'Not Found'
 
   try {
     const custom404Path = path.join(current, '/404.html')
     notFoundResponse = fs.readFileSync(custom404Path, 'utf-8')
-  } catch (err) {
-    notFoundResponse = 'Not Found'
-  }
+  } catch (err) {}
 
   if (!fs.existsSync(related) && flags.single === undefined) {
     return send(res, 404, notFoundResponse)


### PR DESCRIPTION
This checks if `404.html` exists in the current directory and on 404s sends that instead of the default `Not Found` response.