### PR TITLE
add option to ignore custom files and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can find a list of all options [below](#options).
 | -c, --cache [seconds]  | How long static files should be cached in the browser | 3600 |
 | -s, --single           | Serve single page apps with only one `index.html` in the root directory | - |
 | -u, --unzipped         | Disable gzip compression | false |
+| -i, --ignore           | Files and directories to ignore | - |
 
 ## Examples
 

--- a/bin/list
+++ b/bin/list
@@ -21,6 +21,7 @@ args
   .option('cache', 'How long static files should be cached in the browser (seconds)', 3600)
   .option('single', 'Serve single page apps with only one index.html')
   .option('unzipped', 'Disable GZIP compression')
+  .option('ignore', 'Files and directories to ignore')
 
 const flags = args.parse(process.argv)
 const directory = args.sub[0]
@@ -62,10 +63,14 @@ const prepareView = () => {
   return compile(viewContent)
 }
 
-const ignoredFiles = [
+let ignoredFiles = [
   '.DS_Store',
   '.git/'
 ]
+
+if (flags.ignore.length) {
+  ignoredFiles = ignoredFiles.concat(flags.ignore.split(','))
+}
 
 const renderDirectory = async dir => {
   let files = []


### PR DESCRIPTION
This implements an option to customize which files and directories to ignore, as suggested in #26.

I opted to only add an `--ignore` flag instead of parsing `.gitignore` or `.npmignore`. Given how I  personally use `list`, I'd find it inconvenient if everything in my `.gitignore` was not served. I'm happy to implement it though if y'all think that's appropriate!