### PR TITLE
Add large files support

### DIFF
--- a/bin/list
+++ b/bin/list
@@ -16,6 +16,7 @@ import filesize from 'filesize'
 import mime from 'mime'
 import toPromise from 'denodeify'
 import compress from 'micro-compress'
+import stream from 'send'
 
 args
   .option('port', 'Port to listen on', process.env.PORT || 3000)
@@ -232,7 +233,11 @@ const handler = async (req, res) => {
     stats = await toPromise(fs.stat)(related)
     binaryStat = await toPromise(isBinary)(path.parse(related).base, body)
   } catch (err) {
-    throw err
+    if (err instanceof RangeError) {
+      return stream(req, related).pipe(res)
+    } else {
+      throw err
+    }
   }
 
   const getETag = s => '"' + s.dev + '-' + s.ino + '-' + s.mtime.getTime() + '"'

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "istextorbinary": "2.1.0",
     "micro": "^6.0.1",
     "micro-compress": "^1.0.0",
-    "mime": "1.3.4"
+    "mime": "1.3.4",
+    "send": "^0.14.1"
   }
 }


### PR DESCRIPTION
Fixes #14 

Use library https://github.com/pillarjs/send to stream files when they're too big.

*NOTE: Consider this library to replace `send`?*