### PR TITLE
Fix for the `--single` option

### DIFF
--- a/bin/list
+++ b/bin/list
@@ -170,7 +170,7 @@ const renderDirectory = async dir => {
 }
 
 const handler = async (req, res) => {
-  
+
   if (flags.auth) {
     const credentials = auth(req)
 
@@ -185,7 +185,7 @@ const handler = async (req, res) => {
       return send(res, 401, 'Access Denied')
     }
   }
- 
+
   const {pathname} = parse(req.url)
   let related = path.parse(path.join(current, pathname))
 
@@ -208,7 +208,7 @@ const handler = async (req, res) => {
   }
 
   // Check if file or directory path
-  if (path.parse(related).ext === '') {
+  if (await isDir(related)) {
     let indexPath = path.join(related, '/index.html')
 
     res.setHeader('Content-Type', mime.contentType(path.extname(indexPath)))
@@ -232,6 +232,19 @@ const handler = async (req, res) => {
       indexPath = path.join(current, '/index.html')
     }
 
+    let indexContent
+
+    try {
+      indexContent = await fs.readFile(indexPath, 'utf8')
+    } catch (err) {
+      throw err
+    }
+
+    return send(res, 200, indexContent)
+  }
+
+  if (!fs.existsSync(related) && flags.single) {
+    const indexPath = path.join(current, '/index.html')
     let indexContent
 
     try {

--- a/bin/list
+++ b/bin/list
@@ -208,7 +208,7 @@ const handler = async (req, res) => {
   }
 
   // Check if file or directory path
-  if (await isDir(related)) {
+  if (path.parse(related).ext === '') {
     let indexPath = path.join(related, '/index.html')
 
     res.setHeader('Content-Type', mime.contentType(path.extname(indexPath)))


### PR DESCRIPTION
Right now running list with `--single` option doesn't work correctly. I tries to load the file under a specified path, and when it doesn't find it, it crushes with an error:

```
Error: ENOENT: no such file or directory, open '/Users/dominik/Downloads/theory-463759986/whatever'
    at Error (native)
```

The above commit reverts the line that introduced the bug and fixes the behaviour for `--single` option.